### PR TITLE
pulse: Set volume to max when the increase was too huge (#1765)

### DIFF
--- a/src/adapters/pulseaudio.cpp
+++ b/src/adapters/pulseaudio.cpp
@@ -175,8 +175,12 @@ void pulseaudio::inc_volume(int delta_perc) {
   pa_threaded_mainloop_lock(m_mainloop);
   pa_volume_t vol = math_util::percentage_to_value<pa_volume_t>(abs(delta_perc), PA_VOLUME_NORM);
   if (delta_perc > 0) {
-    if (pa_cvolume_max(&cv) + vol <= m_max_volume) {
+    pa_volume_t current = pa_cvolume_max(&cv);
+    if (current + vol <= m_max_volume) {
       pa_cvolume_inc(&cv, vol);
+    } else if (current < m_max_volume) {
+      // avoid rounding errors and set to m_max_volume directly
+      pa_cvolume_scale(&cv, m_max_volume);
     } else {
       m_log.warn("pulseaudio: maximum volume reached");
     }


### PR DESCRIPTION
Previously, when volume was in close proximity to n_max_volume, a larger
increase would not do anything. After this patch, volume is set to
m_max_volume in such scenarios. If the volume already is at
n_max_volume, we mirror the old behavior and emit a warning.

So, for example, consider m_max_volume was 100%, but the volume prior
to the increase was 96%. An increase of 5% would do nothing (emit a
warning, even) instead of setting the volume to 100%.

Note that this might happen even if the volume is at 95% according to
%percentage% due to rounding errors.